### PR TITLE
Fixed naming issue (see issue #5)

### DIFF
--- a/Controller/AttachmentHandler.php
+++ b/Controller/AttachmentHandler.php
@@ -10,7 +10,7 @@ class AttachmentHandler extends BaseController
     {
         $file = $this->getFile();
 
-        $this->response->html($this->template->render('EAR:file/rename', array(
+        $this->response->html($this->template->render('EnableAttachmentRenaming:file/rename', array(
             'file' => $file,
         )));
     }

--- a/Plugin.php
+++ b/Plugin.php
@@ -8,11 +8,11 @@ class Plugin extends Base
 {
     public function initialize()
     {
-        $this->template->hook->attach("template:task-file:images:dropdown", "EAR:rename/attachment");
-        $this->template->hook->attach("template:task-file:documents:dropdown", "EAR:rename/attachment");
+        $this->template->hook->attach("template:task-file:images:dropdown", "EnableAttachmentRenaming:rename/attachment");
+        $this->template->hook->attach("template:task-file:documents:dropdown", "EnableAttachmentRenaming:rename/attachment");
         
-        $this->template->hook->attach("template:project-overview:images:dropdown", "EAR:rename/attachment");
-        $this->template->hook->attach("template:project-overview:documents:dropdown", "EAR:rename/attachment");
+        $this->template->hook->attach("template:project-overview:images:dropdown", "EnableAttachmentRenaming:rename/attachment");
+        $this->template->hook->attach("template:project-overview:documents:dropdown", "EnableAttachmentRenaming:rename/attachment");
     }
 
     public function getPluginName()
@@ -32,7 +32,7 @@ class Plugin extends Base
 
     public function getPluginVersion()
     {
-        return '1.1.2';
+        return '1.1.3';
     }
     
     public function getPluginHomepage()

--- a/Template/file/rename.php
+++ b/Template/file/rename.php
@@ -1,5 +1,5 @@
 <?php
-$params = array('file_id' => $file['id'], 'plugin' => 'EAR');
+$params = array('file_id' => $file['id'], 'plugin' => 'EnableAttachmentRenaming');
 if (isset($file["task_id"]))
 {
     $params["task_id"] = $file["task_id"];

--- a/Template/rename/attachment.php
+++ b/Template/rename/attachment.php
@@ -1,5 +1,5 @@
 <?php
-$params = array('file_id' => $file['id'], 'plugin' => 'EAR');
+$params = array('file_id' => $file['id'], 'plugin' => 'EnableAttachmentRenaming');
 if (isset($file["task_id"]))
 {
     $params["task_id"] = $file["task_id"];


### PR DESCRIPTION
I could fix it for me and made a new branch. But i do not know how to rename the plugin / repo folder name while keeping the repo intakt.

Sorry.

Maybe it helps anyway.

When i rename the "EAR" folder to "EnableAttachmentRenaming" while this version is inside the folder on my Kanboard installation everything is fine again.

Cheers, fx
